### PR TITLE
Add support for HDR imagery to the PNG format

### DIFF
--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -6,19 +6,7 @@ Status: Draft
 ## Problem to be solved
 The gAMA chunk of the Portable Network Graphics (PNG) format (specified in [PNG]) parameterized the transfer function of the image as a power law. As such, it cannot model the Reference PQ or HLG OOTFs specified in [BT2100-1], which are commonly used for HDR images.
 
-This specification uses the existing iCCP chunk to unambiguously signal the color system of an image that uses the Reference PQ EOTF specified in [BT2100-1]. It also allows graceful processing by decoders that do not conform to this specification by recommending fallback values for the gAMA chunk, cHRM chunk, and embedded ICC profile.
-
 An existing W3C group note (https://www.w3.org/TR/png-hdr-pq/) specifies an approach which is limited: it supports signaling of only the ITU BT.2100 PQ EOTF and uses magic values in the iCCP chunk to signal color spaces.
-
-[H.273](https://www.itu.int/rec/T-REC-H.273/en) specifies a controlled vocabulary for the parameterization of
-color space information:
-* Color Primaries
-* Transfer Function
-* Matrix Coefficients (only required if essence is stored as Y’CbCr)
-
-Use [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) “recommendations” to signal the controlled vocabulary for image formats commonly used for baseband linear broadcasts or file-based Video-on-Demand(VOD) services.
-* Tables within this document summarize values most commonly used in broadcast for 47 different standards documents including H.273
-
 
 ## Basic requirements
 * does not break current implementations
@@ -37,6 +25,17 @@ H.273 color space parameters:
 
 [ed.: these are inspired from recent JPEG standards that incorporate
 H.273 color space parameters]
+
+This specification uses the existing iCCP chunk to unambiguously signal the color system of an image that uses the Reference PQ EOTF specified in [BT2100-1]. It also allows graceful processing by decoders that do not conform to this specification by recommending fallback values for the gAMA chunk, cHRM chunk, and embedded ICC profile.
+
+[H.273](https://www.itu.int/rec/T-REC-H.273/en) specifies a controlled vocabulary for the parameterization of
+color space information:
+* Color Primaries
+* Transfer Function
+* Matrix Coefficients (only required if essence is stored as Y’CbCr)
+
+Use [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) “recommendations” to signal the controlled vocabulary for image formats commonly used for baseband linear broadcasts or file-based Video-on-Demand(VOD) services.
+* Tables within this document summarize values most commonly used in broadcast for 47 different standards documents including H.273
 
 ## A. References
 ### A.1 Normative references

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -20,11 +20,12 @@ H.273 color space parameters:
 
 * COLPRIMS, 2 bytes, One of the ColourPrimaries enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
 * TRANSFC, 2 bytes, One of the TransferCharacteristics enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
-* MATCOEFFS, 2 bytes, One of the MatrixCoefficients enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
 * VIDFRNG, 1 byte, Value of the VideoFullRangeFlag specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
 
 [ed.: these are inspired from recent JPEG standards that incorporate
 H.273 color space parameters]
+
+[ed.: The MATOEFFS parameter is not included because PNG does not support YCbCr]
 
 This specification uses the existing iCCP chunk to unambiguously signal the color system of an image that uses the Reference PQ EOTF specified in [BT2100-1]. It also allows graceful processing by decoders that do not conform to this specification by recommending fallback values for the gAMA chunk, cHRM chunk, and embedded ICC profile.
 

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -40,6 +40,8 @@ When the cICP chunk is present, PNG decoders that recognize it shall ignore the 
 NOTE: [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) summarize combinations of H.273 parameters corresponding to common baseband linear broadcasts and file-based Video-on-Demand(VOD) services.
 
 ## A. References
+
+[ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I). Series H: Audiovisual and multimedia systems - Usage of video signal type code points
 [BT2100-1]
 [Recommendation ITU-R BT.2100-1](https://www.itu.int/rec/R-REC-BT.2100), Image parameter values for high dynamic range television for use in production and international programme exchange
 

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -18,9 +18,9 @@ An existing W3C group note, [BT2100-in-PNG]  specifies an approach which is limi
 Define a cICP chunk that contains the 7 bytes necessary to carry the
 H.273 color space parameters:
 
-* COLPRIMS, 2 bytes, One of the ColourPrimaries enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23091-2
-* TRANSFC, 2 bytes, One of the TransferCharacteristics enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23091-2
-* VIDFRNG, 1 byte, Value of the VideoFullRangeFlag specified in Rec. ITU-T H.273 | ISO/IEC 23091-2
+* COLPRIMS, 2 bytes, One of the ColourPrimaries enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
+* TRANSFC, 2 bytes, One of the TransferCharacteristics enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
+* VIDFRNG, 1 byte, Value of the VideoFullRangeFlag specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
 
 [ed.: these are inspired from recent JPEG standards that incorporate
 H.273 color space parameters]
@@ -51,3 +51,6 @@ Use [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-
 
 [BT2100-in-PNG]
 [Using the ITU BT.2100 PQ EOTF with the PNG format](https://www.w3.org/TR/png-hdr-pq/)
+
+[ISO/IEC 23091-2]
+[ISO/IEC 23091-2](https://www.iso.org/standard/81546.html)

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -6,7 +6,7 @@ Status: Draft
 ## Problem to be solved
 The gAMA chunk of the Portable Network Graphics (PNG) format (specified in [PNG]) parameterized the transfer function of the image as a power law. As such, it cannot model the Reference PQ or HLG OOTFs specified in [BT2100-1], which are commonly used for HDR images.
 
-An existing W3C group note (https://www.w3.org/TR/png-hdr-pq/) specifies an approach which is limited: it supports signaling of only the ITU BT.2100 PQ EOTF and uses magic values in the iCCP chunk to signal color spaces.
+An existing W3C group note, [BT2100-in-PNG]  specifies an approach which is limited: it supports signaling of only the ITU BT.2100 PQ EOTF and uses magic values in the iCCP chunk to signal color spaces.
 
 ## Basic requirements
 * does not break current implementations
@@ -47,3 +47,6 @@ Use [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-
 
 [PNG]
 [Portable Network Graphics (PNG) Specification (Second Edition)](https://www.w3.org/TR/PNG/). Tom Lane. W3C. 10 November 2003. W3C Recommendation. URL: https://www.w3.org/TR/PNG
+
+[BT2100-in-PNG]
+[Using the ITU BT.2100 PQ EOTF with the PNG format](https://www.w3.org/TR/png-hdr-pq/)

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -1,0 +1,50 @@
+# Adding support for HDR imagery to the PNG format
+Authors (alphabetical): Chris Blume, Chris Seeger, Pierre-Anthony Lemieux
+
+Status: Draft
+
+## Problem to be solved
+The gAMA chunk of the Portable Network Graphics (PNG) format (specified in [PNG]) parameterized the transfer function of the image as a power law. As such, it cannot model the Reference PQ or HLG OTFs specified in [BT2100-1], which are commonly used for HDR images.
+
+This specification uses the existing iCCP chunk to unambiguously signal the color system of an image that uses the Reference PQ EOTF specified in [BT2100-1]. It also allows graceful processing by decoders that do not conform to this specification by recommending fallback values for the gAMA chunk, cHRM chunk, and embedded ICC profile.
+
+An existing W3C group note (https://www.w3.org/TR/png-hdr-pq/) specifies an approach which is limited: it supports signaling of only the ITU BT.2100 PQ EOTF and uses magic values in the iCCP chunk to signal color spaces.
+
+[H.273](https://www.itu.int/rec/T-REC-H.273/en) specifies a controlled vocabulary for the parameterization of
+color space information:
+* Color Primaries
+* Transfer Function
+* Matrix Coefficients (only required if essence is stored as Y’CbCr)
+
+Use [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) “recommendations” to signal the controlled vocabulary for image formats commonly used for baseband linear broadcasts or file-based Video-on-Demand(VOD) services.
+* Tables within this document summarize values most commonly used in broadcast for 47 different standards documents including H.273
+
+
+## Basic requirements
+* does not break current implementations
+* extensible signaling of color space based on H.273
+* does not require the presence of iCCP chunk and embedded ICC profiles
+* cICP chunk comes before frame data
+
+## Strawman approach
+Define a cICP chunk that contains the 7 bytes necessary to carry the
+H.273 color space parameters:
+
+* COLPRIMS, 2 bytes, One of the ColourPrimaries enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
+* TRANSFC, 2 bytes, One of the TransferCharacteristics enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
+* MATCOEFFS, 2 bytes, One of the MatrixCoefficients enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
+* VIDFRNG, 1 byte, Value of the VideoFullRangeFlag specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
+
+[ed.: these are inspired from recent JPEG standards that incorporate
+H.273 color space parameters]
+
+## A. References
+### A.1 Normative references
+[BT2100-1]
+[Recommendation ITU-R BT.2100-1](https://www.itu.int/rec/R-REC-BT.2100), Image parameter values for high dynamic range television for use in production and international programme exchange
+
+[ITU-T H.273]
+[Technical Document ITU-T H.273](https://www.itu.int/rec/T-REC-H.273/en), Color Independent Coding Points for Images
+
+[PNG]
+[Portable Network Graphics (PNG) Specification (Second Edition)](https://www.w3.org/TR/PNG/). Tom Lane. W3C. 10 November 2003. W3C Recommendation. URL: https://www.w3.org/TR/PNG

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -1,5 +1,5 @@
 # Adding support for HDR imagery to the PNG format
-Authors (alphabetical): Chris Blume, Chris Seeger, Pierre-Anthony Lemieux
+Authors (alphabetical): Chris Blume, Pierre-Anthony Lemieux, Chris Seeger
 
 Status: Draft
 

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -37,7 +37,7 @@ When the cICP chunk is present, PNG decoders that recognize it shall ignore the 
 - cHRM 
 - sRGB 
 
-Use [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) “recommendations” to signal the controlled vocabulary for image formats commonly used for baseband linear broadcasts or file-based Video-on-Demand(VOD) services.
+NOTE: [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) summarize combinations of H.273 parameters corresponding to common baseband linear broadcasts and file-based Video-on-Demand(VOD) services.
 
 ## A. References
 [BT2100-1]

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -27,7 +27,11 @@ H.273 color space parameters]
 
 [ed.: The MATOEFFS parameter is not included because PNG does not support YCbCr]
 
-This specification uses the existing iCCP chunk to unambiguously signal the color system of an image that uses the Reference PQ EOTF specified in [BT2100-1]. It also allows graceful processing by decoders that do not conform to this specification by recommending fallback values for the gAMA chunk, cHRM chunk, and embedded ICC profile.
+When the cICP chunk is present, PNG decoders that recognize it shall ignore the following chunks:
+- iCCP
+- gAMA 
+- cHRM 
+- sRGB 
 
 [H.273](https://www.itu.int/rec/T-REC-H.273/en) specifies a controlled vocabulary for the parameterization of
 color space information:

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -1,5 +1,5 @@
 # Adding support for HDR imagery to the PNG format
-Authors (alphabetical): Chris Blume, Pierre-Anthony Lemieux, Chris Seeger
+Editors: Chris Blume, Pierre-Anthony Lemieux, Chris Seeger
 
 Status: Draft
 

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -14,6 +14,9 @@ An existing W3C group note, [BT2100-in-PNG]  specifies an approach which is limi
 * does not require the presence of iCCP chunk and embedded ICC profiles
 
 ## Strawman approach
+[H.273](https://www.itu.int/rec/T-REC-H.273/en) specifies a controlled vocabulary for the parameterization of
+color space information.
+
 Define a cICP chunk that contains the 7 bytes necessary to carry the
 H.273 color space parameters:
 
@@ -33,12 +36,6 @@ When the cICP chunk is present, PNG decoders that recognize it shall ignore the 
 - gAMA 
 - cHRM 
 - sRGB 
-
-[H.273](https://www.itu.int/rec/T-REC-H.273/en) specifies a controlled vocabulary for the parameterization of
-color space information:
-* Color Primaries
-* Transfer Function
-* Matrix Coefficients (only required if essence is stored as Y’CbCr)
 
 Use [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) “recommendations” to signal the controlled vocabulary for image formats commonly used for baseband linear broadcasts or file-based Video-on-Demand(VOD) services.
 * Tables within this document summarize values most commonly used in broadcast for 47 different standards documents including H.273

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -18,9 +18,9 @@ An existing W3C group note, [BT2100-in-PNG]  specifies an approach which is limi
 Define a cICP chunk that contains the 7 bytes necessary to carry the
 H.273 color space parameters:
 
-* COLPRIMS, 2 bytes, One of the ColourPrimaries enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
-* TRANSFC, 2 bytes, One of the TransferCharacteristics enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
-* VIDFRNG, 1 byte, Value of the VideoFullRangeFlag specified in Rec. ITU-T H.273 | ISO/IEC 23001-8
+* COLPRIMS, 2 bytes, One of the ColourPrimaries enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23091-2
+* TRANSFC, 2 bytes, One of the TransferCharacteristics enumerated values specified in Rec. ITU-T H.273 | ISO/IEC 23091-2
+* VIDFRNG, 1 byte, Value of the VideoFullRangeFlag specified in Rec. ITU-T H.273 | ISO/IEC 23091-2
 
 [ed.: these are inspired from recent JPEG standards that incorporate
 H.273 color space parameters]

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -24,7 +24,7 @@ Use [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-
 * does not break current implementations
 * extensible signaling of color space based on H.273
 * does not require the presence of iCCP chunk and embedded ICC profiles
-* cICP chunk comes before frame data
+* cICP chunk comes before IDAT chunk
 
 ## Strawman approach
 Define a cICP chunk that contains the 7 bytes necessary to carry the

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -43,7 +43,6 @@ Use [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-
 * Tables within this document summarize values most commonly used in broadcast for 47 different standards documents including H.273
 
 ## A. References
-### A.1 Normative references
 [BT2100-1]
 [Recommendation ITU-R BT.2100-1](https://www.itu.int/rec/R-REC-BT.2100), Image parameter values for high dynamic range television for use in production and international programme exchange
 

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -4,7 +4,7 @@ Authors (alphabetical): Chris Blume, Chris Seeger, Pierre-Anthony Lemieux
 Status: Draft
 
 ## Problem to be solved
-The gAMA chunk of the Portable Network Graphics (PNG) format (specified in [PNG]) parameterized the transfer function of the image as a power law. As such, it cannot model the Reference PQ or HLG OTFs specified in [BT2100-1], which are commonly used for HDR images.
+The gAMA chunk of the Portable Network Graphics (PNG) format (specified in [PNG]) parameterized the transfer function of the image as a power law. As such, it cannot model the Reference PQ or HLG OOTFs specified in [BT2100-1], which are commonly used for HDR images.
 
 This specification uses the existing iCCP chunk to unambiguously signal the color system of an image that uses the Reference PQ EOTF specified in [BT2100-1]. It also allows graceful processing by decoders that do not conform to this specification by recommending fallback values for the gAMA chunk, cHRM chunk, and embedded ICC profile.
 

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -38,7 +38,6 @@ When the cICP chunk is present, PNG decoders that recognize it shall ignore the 
 - sRGB 
 
 Use [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) “recommendations” to signal the controlled vocabulary for image formats commonly used for baseband linear broadcasts or file-based Video-on-Demand(VOD) services.
-* Tables within this document summarize values most commonly used in broadcast for 47 different standards documents including H.273
 
 ## A. References
 [BT2100-1]

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -12,7 +12,6 @@ An existing W3C group note, [BT2100-in-PNG]  specifies an approach which is limi
 * does not break current implementations
 * extensible signaling of color space based on H.273
 * does not require the presence of iCCP chunk and embedded ICC profiles
-* cICP chunk comes before IDAT chunk
 
 ## Strawman approach
 Define a cICP chunk that contains the 7 bytes necessary to carry the
@@ -26,6 +25,8 @@ H.273 color space parameters:
 H.273 color space parameters]
 
 [ed.: The MATOEFFS parameter is not included because PNG does not support YCbCr]
+
+The cICP chunk comes before IDAT chunk.
 
 When the cICP chunk is present, PNG decoders that recognize it shall ignore the following chunks:
 - iCCP


### PR DESCRIPTION
This commit adds a proposal to ammend the PNG specification to
add support for a new cICP chunk that enabled HDR support.

Closes #11