### PR TITLE
Add MATCOEFFS

### DIFF
--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -38,7 +38,6 @@ When the cICP chunk is present, PNG decoders that recognize it shall ignore the 
 
 NOTE: [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) summarize combinations of H.273 parameters corresponding to common baseband linear broadcasts and file-based Video-on-Demand(VOD) services.
 
-[PNG](https://www.w3.org/TR/PNG/) section 4.4, figure 4.6, and section 6.1 should be updated to include a YUV 4:4:4 image type.
 
 ## A. References
 

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -22,7 +22,7 @@ H.273 color space parameters:
 
 * COLPRIMS, 2 bytes, One of the ColourPrimaries enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
 * TRANSFC, 2 bytes, One of the TransferCharacteristics enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
-* MATOEFFS, 1 byte, One of the MatrixCoefficients enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
+* MATCOEFFS, 1 byte, One of the MatrixCoefficients enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
 * VIDFRNG, 1 byte, Value of the VideoFullRangeFlag specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
 
 [ed.: these are inspired from recent JPEG standards that incorporate

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -22,12 +22,11 @@ H.273 color space parameters:
 
 * COLPRIMS, 2 bytes, One of the ColourPrimaries enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
 * TRANSFC, 2 bytes, One of the TransferCharacteristics enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
+* MATOEFFS, 1 byte, One of the MatrixCoefficients enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
 * VIDFRNG, 1 byte, Value of the VideoFullRangeFlag specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
 
 [ed.: these are inspired from recent JPEG standards that incorporate
 H.273 color space parameters]
-
-[ed.: The MATOEFFS parameter is not included because PNG does not support YCbCr]
 
 The cICP chunk comes before IDAT chunk.
 

--- a/png_cicp_chunk_proposal.md
+++ b/png_cicp_chunk_proposal.md
@@ -38,6 +38,8 @@ When the cICP chunk is present, PNG decoders that recognize it shall ignore the 
 
 NOTE: [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) summarize combinations of H.273 parameters corresponding to common baseband linear broadcasts and file-based Video-on-Demand(VOD) services.
 
+[PNG](https://www.w3.org/TR/PNG/) section 4.4, figure 4.6, and section 6.1 should be updated to include a YUV 4:4:4 image type.
+
 ## A. References
 
 [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I). Series H: Audiovisual and multimedia systems - Usage of video signal type code points


### PR DESCRIPTION
During the 2021-02-24 meeting there was interest in supporting narrow range in PNGs. This implies the requirement of YUV support in PNG.

PNG doesn't currently have a way to specify different sizes for different planes. Until that is added, formats like 4:2:0 cannot be used. However, 4:4:4 is a possibility.

This pull request adds wording for enabling YUV 4:4:4 support to PNG.
Closes #16 