### PR TITLE
Fix formatting

### DIFF
--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -82,6 +82,7 @@ A PNG datastream shall contain at most one embedded profile, whether specified e
 [ICC-2010] Specification ICC.1:2010-12 (Profile version 4.3.0.0) Image technology colour management - Architecture, profile format, and data structure
 
 [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I). Series H: Audiovisual and multimedia systems - Usage of video signal type code points
+
 [BT2100-1]
 [Recommendation ITU-R BT.2100-1](https://www.itu.int/rec/R-REC-BT.2100), Image parameter values for high dynamic range television for use in production and international programme exchange
 


### PR DESCRIPTION
A missing newline caused a reference to appear as a continuation of a the previous reference.

This commit inserts the missing newline.