### PR TITLE
cICP chunk is 4 bytes, not 3

### DIFF
--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -22,7 +22,7 @@ An existing W3C group note, [BT2100-in-PNG]  specifies an approach which is limi
 
 [H.273](https://www.itu.int/rec/T-REC-H.273/en) specifies a controlled vocabulary for the parameterization of color space information.
 
-Define a `cICP` chunk that contains the 3 bytes necessary to carry the H.273 color space parameters:
+Define a `cICP` chunk that contains the 4 bytes necessary to carry the H.273 color space parameters:
 
 * **COLPRIMS**, 1 byte, One of the ColourPrimaries enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]
 * **TRANSFC**, 1 byte, One of the TransferCharacteristics enumerated values specified in Rec. ITU-T H.273 | [ISO/IEC 23091-2]


### PR DESCRIPTION
The proposed cICP chunk is currently described as 3 bytes. That is
then followed by how it actually uses 4 bytes.

This commit corrects the description to always list the cICP chunk
as 4 bytes.

Closes #21