### PR TITLE
Reference unversioned BT.2100

### DIFF
--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -4,7 +4,7 @@ Editors: Chris Blume, Pierre-Anthony Lemieux, Chris Seeger, Leonard Rosenthol
 Status: Draft
 
 ## Problem to be solved
-The gAMA chunk of the Portable Network Graphics (PNG) format (specified in [PNG]) parameterized the transfer function of the image as a power law. As such, it cannot model the Reference PQ or HLG OOTFs specified in [BT2100-1], which are commonly used for HDR images.
+The gAMA chunk of the Portable Network Graphics (PNG) format (specified in [PNG]) parameterized the transfer function of the image as a power law. As such, it cannot model the Reference PQ or HLG OOTFs specified in [BT2100], which are commonly used for HDR images.
 
 An existing W3C group note, [BT2100-in-PNG]  specifies an approach which is limited: it supports signaling of only the ITU BT.2100 PQ EOTF and uses magic values in the iCCP chunk to signal color spaces.
 
@@ -83,8 +83,8 @@ A PNG datastream shall contain at most one embedded profile, whether specified e
 
 [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I). Series H: Audiovisual and multimedia systems - Usage of video signal type code points
 
-[BT2100-1]
-[Recommendation ITU-R BT.2100-1](https://www.itu.int/rec/R-REC-BT.2100), Image parameter values for high dynamic range television for use in production and international programme exchange
+[BT2100]
+[Recommendation ITU-R BT.2100](https://www.itu.int/rec/R-REC-BT.2100), Image parameter values for high dynamic range television for use in production and international programme exchange
 
 [ITU-T H.273]
 [Technical Document ITU-T H.273](https://www.itu.int/rec/T-REC-H.273/en), Color Independent Coding Points for Images


### PR DESCRIPTION
Currently, the proposal references BT.2100-1 explicitly, despite
linking to the unversioned BT.2100. It seems like the -1 version
is not actually an important detail.

This commit removes the version and instead references the
future-proof, unversioned BT.2100.

Closes #26