### PR TITLE
iCCP and iCCN specify different ICC versions

### DIFF
--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -61,7 +61,10 @@ The profile name may be any convenient name for referring to the profile. It is 
 
 The only compression method defined in this International Standard is method 0 (zlib datastream with deflate compression, see 10.3: Other uses of compression). The compression method entry is followed by a compressed datastream of an ICC profile as defined in [ICC] or [ICC-2010]. The ICC profile shall either be an output profile (Device Class = `prtr`) or a monitor profile (Device Class = `mntr`). Decompression of this datastream yields the embedded ICC profile.
 
-NOTE: This is exactly the same as `iCCP` except the profile name is UTF-8 instead of Latin-1. Analogous to `tEXt` vs. `iTXt`
+NOTE: This is exactly the same as `iCCP` except:
+
+* `iCCP` is ICCv2 (although many decoders treat it as ICCv4) while `iCCN` is explicitly ICCv4
+* the profile name is UTF-8 instead of Latin-1. Analogous to `tEXt` vs. `iTXt`
 
 #### Encoder
 


### PR DESCRIPTION
The HDR in PNG proposal currently says the only difference between
the iCCP and iCCN chunks is Latin-1 vs. UTF-8 profile names.

But this is not completely correct. The PNG spec explicitly says
iCCP is ICCv2. Although many decoders treat iCCP as ICCv4, the
iCCN chunk would be explicitly ICCv4.

This commit clarifies this distinction.

Closes #30