### PR TITLE
Remove inconsistent behavior

### DIFF
--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -35,7 +35,7 @@ NOTE: [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-20191
 
 The `cICP` chunk SHALL come before `IDAT` chunk.  
 
-A PNG MAY contain both a `cICP` chunk and an `iCCP` chunk. If a PNG decoder detects the presence of both a `cICP` and a `iCCP` chunk, the behavior is undefined.
+A PNG MAY contain both a `cICP` chunk and an `iCCP` chunk.
 
 When the `cICP` chunk is present, a PNG decoder SHALL ignore the following chunks:
 - `gAMA`


### PR DESCRIPTION
In the current HDR in PNG proposal, there is a line that describes
a decoder encountering a cICP chunk and an iCCP chunk would have
undefined behavior.

However, later in the same proposal the exact behavior is spelled out.

This commit removes the undefined behavior, leaving the behavior
agreed upon.

Closes #32 