### PR TITLE
Specify that a cICP chunk should ignore iCCP chunks

### DIFF
--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -69,7 +69,7 @@ If the `iCCN` chunk is present, the image samples conform to the colour space re
 
 ### Decoder
 
-If the image contains a `cICP` chunk and will be rendered to a display or surface that supports `cICP`, then the PNG decoder shall ignore any `gAMA`, `cHRM`, and `iCCN` chunks and use the `cICP` chunk instead. Otherwise, when a `iCCN` chunk is present, PNG decoders that recognize it and are capable of colour management shall ignore any `gAMA`, `cHRM`, and `cICP` chunks and use the `iCCN` chunk instead and interpret it according to [ICC] or [ICC-2010] as appropriate. PNG decoders that are used in an environment that is incapable of full-fledged colour management shall use the `gAMA` and `cHRM` chunks if present.
+If the image contains a `cICP` chunk and will be rendered to a display or surface that supports `cICP`, then the PNG decoder shall ignore any `gAMA`, `cHRM`, `iCCP`, and `iCCN` chunks and use the `cICP` chunk instead. Otherwise, when a `iCCN` chunk is present, PNG decoders that recognize it and are capable of colour management shall ignore any `gAMA`, `cHRM`, and `cICP` chunks and use the `iCCN` chunk instead and interpret it according to [ICC] or [ICC-2010] as appropriate. PNG decoders that are used in an environment that is incapable of full-fledged colour management shall use the `gAMA` and `cHRM` chunks if present.
 
 #### Codestream
 


### PR DESCRIPTION
The HDR in PNG proposal was a strict order of what chunks should cause
others to be ignored. However, a piece of it is missing and must be
inferred.

This commit clearly spells the ignored chunks.

Closs #34