### PR TITLE
Fix typos in Extended RGB colorspace definitions

### DIFF
--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -131,7 +131,7 @@ The component signals are mapped to red, green and blue tristimulus values accor
        with E' ∈ ℝ
 ```
 
-where `E` is the non-linear colour value and `E` is the linear colour value
+where `E'` is the non-linear colour value and `E` is the linear colour value
 
 _NOTE:_ The color primary chromaticities, white point chromaticity and transfer function are those of the scRGB-nl system specified at ISO/IEC 61966-2-2. Other aspects of ISO/IEC 61966-2-2 do not apply.
 
@@ -143,7 +143,7 @@ The component signals are mapped to red, green and blue tristimulus values accor
 * Green primary chromaticity: `(0.300, 0.600)`
 * Blue primary chromaticity: `(0.150, 0.060)`
 * White point chromaticity: `(0.3127, 0.3290)`
-* Transfer function: `E = E', with E' ∈ ℝ` where `E` is the non-linear colour value and `E` is the linear colour value
+* Transfer function: `E = E', with E' ∈ ℝ` where `E'` is the non-linear colour value and `E` is the linear colour value
 
 
 _NOTE:_ The color primary chromaticities, white point chromaticity and transfer function are those of the scRGB system specified at ISO/IEC 61966-2-2. Other aspects of ISO/IEC 61966-2-2 do not apply.


### PR DESCRIPTION
Closes #45