### PR TITLE
Remove superfluous wording

### DIFF
--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -46,10 +46,6 @@ When the `cICP` chunk is present, a PNG decoder SHALL ignore the following chunk
 
 #### Structure
 
-The four-byte chunk type field contains the decimal values
-
-`105 67 67 80`
-
 The `iCCN` chunk contains:
 
 | Profile name |  1-79 bytes (character string)


### PR DESCRIPTION
The proposal currently specifies the ASCII values along with the
characters that represent the chunk identifier.

The ASCII values are unneeded. The characters are clear enough on
their own.

This commit removes the ASCII values.