### PR TITLE
Explicitly state two proposed chunks

### DIFF
--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -18,7 +18,9 @@ An existing W3C group note, [BT2100-in-PNG]  specifies an approach which is limi
 
 ## Strawman approach
 
-Two new PNG chunks are proposed, the `cICP` chunk and the `iCCN` chunk. Both of these new chunks SHALL come before the `IDAT` chunk. The `cICP` chunk acts as a color space label (much like the existing `sRGB` chunk), naming a color space that the viewer should understand. The `iCCN` chunk acts as a color space profile, providing the exact details of the color space.
+Two new PNG chunks are proposed, the `cICP` chunk and the `iCCN` chunk.
+
+The `cICP` chunk acts as a color space label (much like the existing `sRGB` chunk), specifying the color space to which the pixels within the PNG file conforms. The `iCCN` chunk (much like the existing `iCCP`) contains en embedded color profile.
 
 ### cICP chunk
 

--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -24,6 +24,8 @@ The `cICP` chunk acts as a color space label (much like the existing `sRGB` chun
 
 ### cICP chunk
 
+This chunk SHALL come before the `IDAT` chunk.
+
 [H.273](https://www.itu.int/rec/T-REC-H.273/en) specifies a controlled vocabulary for the parameterization of color space information.
 
 Define a `cICP` chunk that contains the 4 bytes necessary to carry the H.273 color space parameters:
@@ -45,6 +47,8 @@ When the `cICP` chunk is present, a PNG decoder SHALL ignore the following chunk
 - `sRGB` 
 
 ### iCCN chunk Embedded ICC profile (updated)
+
+This chunk SHALL come before the `IDAT` chunk.
 
 #### Structure
 

--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -18,6 +18,8 @@ An existing W3C group note, [BT2100-in-PNG]  specifies an approach which is limi
 
 ## Strawman approach
 
+Two new PNG chunks are proposed, the `cICP` chunk and the `iCCN` chunk. Both of these new chunks SHALL come before the `IDAT` chunk. The `cICP` chunk acts as a color space label (much like the existing `sRGB` chunk), naming a color space that the viewer should understand. The `iCCN` chunk acts as a color space profile, providing the exact details of the color space.
+
 ### cICP chunk
 
 [H.273](https://www.itu.int/rec/T-REC-H.273/en) specifies a controlled vocabulary for the parameterization of color space information.
@@ -32,8 +34,6 @@ Define a `cICP` chunk that contains the 4 bytes necessary to carry the H.273 col
 NOTE: While these are inspired from recent JPEG standards (eg. JPEG-XL) that incorporate these color space parameters, this specification follows H.273.
 
 NOTE: [ITU-T Series H Supplement 19](https://www.itu.int/rec/T-REC-H.Sup19-201910-I) summarize combinations of H.273 parameters corresponding to common baseband linear broadcasts and file-based Video-on-Demand(VOD) services.
-
-The `cICP` chunk SHALL come before `IDAT` chunk.  
 
 A PNG MAY contain both a `cICP` chunk and an `iCCP` chunk.
 

--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -20,7 +20,7 @@ An existing W3C group note, [BT2100-in-PNG]  specifies an approach which is limi
 
 Two new PNG chunks are proposed, the `cICP` chunk and the `iCCN` chunk.
 
-The `cICP` chunk acts as a color space label (much like the existing `sRGB` chunk), specifying the color space to which the pixels within the PNG file conforms. The `iCCN` chunk (much like the existing `iCCP`) contains en embedded color profile.
+The `cICP` chunk acts as a color space label (much like the existing `sRGB` chunk), specifying the color space to which the pixels within the PNG file conforms. The `iCCN` chunk (much like the existing `iCCP`) contains an embedded color profile.
 
 ### cICP chunk
 


### PR DESCRIPTION
Currently, the proposal mentions the details of two chunks without
explaining that these two chunks are the proposed new chunks to
address the issue.

To people who were at the meetings, it may be clear enough. But to
an external reader, it could seem like a mind dump without clarity.

This commit explicitly states that the two chunks are new to this
proposal and how they should work.