### PR TITLE
Issues/0050 colour space conversion examples

### DIFF
--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -201,11 +201,15 @@ The domain and range of this conversion consist of all real values and the compo
 
 * Connection matrix: matrix to convert the [sRGB primaries](https://www.w3.org/TR/css-color-4/#valdef-color-srgb) to the primary colours specified in Rec. ITU-R BT.2100
 
+* Linear light scaling: 1.0
+
 #### `extended-srgb`
 
 * Transfer function: See [extended-linear-srgb](#extended-linear-srgb)
 
 * Connection matrix: matrix to convert the [sRGB primaries](https://www.w3.org/TR/css-color-4/#valdef-color-srgb) to the primary colours specified in Rec. ITU-R BT.2100
+
+* Linear light scaling: 1.0
 
 _Note:_ The domain of this transformation function is all real values. Its domain is not restricted to the unit interval [0, 1].
 

--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -238,7 +238,7 @@ _Note:_ The factor of 300 is such that a display luminance of 300 cd/m<sup>2</su
 _Note:_ The domain of `EOTF<sup>-1</sup>` is [0, 10000]
 
 
-#### Example conversions via Color Connection Space
+#### Conversions via Color Connection Space
 
 ##### Conversion from extended-sRGB to HLG
 
@@ -263,6 +263,30 @@ _Note 2:_ See section 5.3 in ITU-R BT.2408-4 relating to negative transfer funct
       r1 = srgb_eotf(R)
       g1 = srgb_eotf(G)
       b1 = srgb_eotf(B)
+      (r2,g2,b2) = matrixXYZtoBT2020(matrixSRGBtoXYZ(r1,g1,b1))
+      r3 = linearLightScaler * r2
+      g3 = linearLightScaler * g2
+      b3 = linearLightScaler * b2
+      (r4,g4,b4) = hlg_ootf(r3,g3,b3,systemGamma)
+      (r5,g5,b5) = hlg_oetf(r4,g4,b4)
+      return (r5,g5,b5)
+```
+
+##### Conversion from extended-linear-sRGB to HLG
+
+_Input:_ Full-range non-linear floating-point `extended-linear-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+_Output:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
+_Process:_
+  1. Convert from `extended-linear-srgb` color space to `rec2100-hlg` color space
+  2. Scale pixel values - See Note 1
+  3. Apply HLG Inverse EOTF to convert to HLG from Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
+    * apply HLG Inverse OOTF
+    * apply HLG OETF - See Note 2
+
+```python
+    def convertExtendedLinearSRGBtoREC2100HLG(R,G,B):
+      systemGamma = 1.0
+      linearLightScaler = 0.265
       (r2,g2,b2) = matrixXYZtoBT2020(matrixSRGBtoXYZ(r1,g1,b1))
       r3 = linearLightScaler * r2
       g3 = linearLightScaler * g2

--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -77,7 +77,7 @@ Add a new `CanvasStorageFormat` enum to allow for higher bit storage formats.
   enum CanvasStorageFormat {
     'unorm-8',
     'unorm-10-10-10-2',
-    'float-16', 
+    'float-16',
   }
 ```
 
@@ -100,8 +100,11 @@ WebGPU's ``GPUSwapChainDescriptor`` can allow for specifying higher bit depth fo
 As illustrated below, the proposal assumes that tone mapping, i.e. the rendering of an image with a given dynamic range onto a
 display with different dynamic range, occurs in different parts of the system depending on the color space of the Canvas element:
 
-* in the case where `rec2100-hlg` or `rec2100-pq` are used, tone mapping is performed by the platform. This is akin to the
-  scenario where the `src` of an `img` element is a PQ or HLG image.
+* in the case where `rec2100-pq` are used, tone mapping is performed by the platform. This is akin to the
+  scenario where the `src` of an `img` element is a PQ image.
+
+* in the case where `rec2100-hlg` are used, tone mapping is performed by the display device. This is akin to the
+  scenario where the `src` of an `img` element is an HLG image.
 
 * in the case where `extended-linear-srgb` or `extended-srgb` are used, tone mapping is performed by the web app, using display capabilities provided by the platform.
 

--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -384,7 +384,9 @@ function convertREC2100HLGtoExtendedSRGB(r, g, b) {
   const b3 = linearLightScaler * b2;
 
   const [r4, g4, b4] = matrixXYZtoSRGB(matrixBT2020toXYZ(r3, g3, b3));
-  const [r5, g5, b5] = srgb_inverse_eotf(r4, g4, b4);
+  const r5 = srgb_inverse_eotf(r4);
+  const g5 = srgb_inverse_eotf(g4);
+  const b5 = srgb_inverse_eotf(b4);
 
   return [r5, g5, b5];
 }

--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -267,7 +267,7 @@ _Note 2:_ See section 5.3 in ITU-R BT.2408-4 relating to negative transfer funct
       r3 = linearLightScaler * r2
       g3 = linearLightScaler * g2
       b3 = linearLightScaler * b2
-      (r4,g4,b4) = hlg_ootf(r3,g3,b3,systemGamma)
+      (r4,g4,b4) = hlg_inverse_ootf(r3,g3,b3,systemGamma)
       (r5,g5,b5) = hlg_oetf(r4,g4,b4)
       return (r5,g5,b5)
 ```
@@ -291,10 +291,86 @@ _Process:_
       r3 = linearLightScaler * r2
       g3 = linearLightScaler * g2
       b3 = linearLightScaler * b2
-      (r4,g4,b4) = hlg_ootf(r3,g3,b3,systemGamma)
+      (r4,g4,b4) = hlg_inverse_ootf(r3,g3,b3,systemGamma)
       (r5,g5,b5) = hlg_oetf(r4,g4,b4)
       return (r5,g5,b5)
 ```
+
+##### Conversion from extended-sRGB to PQ
+
+_Input:_ Full-range non-linear floating-point `extended-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+_Output:_ Full-range non-linear floating-point `rec2100-pq` pixel with black at 0.0 and diffuse white at ???. Values may exist outside the range 0.0 to 1.0.
+_Process:_
+
+##### Conversion from extended-sRGB to PQ
+
+_Input:_ Full-range non-linear floating-point `extended-linear-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+_Output:_ Full-range non-linear floating-point `rec2100-pq` pixel with black at 0.0 and diffuse white at ???. Values may exist outside the range 0.0 to 1.0.
+_Process:_
+
+##### Conversion from HLG to extended-sRGB
+
+_Input:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
+_Output:_ Full-range non-linear floating-point `extended-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+_Process:_
+  1. Apply HLG EOTF to convert the non-linear `rec2100-hlg` Signal to linear Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
+    * apply inverse HLG OETF
+    * apply HLG OOTF to derive linear display light
+  2. Scale pixel values
+  3. Convert from ITU BT.2100-1 color space to SRGB color space
+  4. Convert to non-linear SRGB using the SRGB Inverse EOTF
+
+  ```python
+      def convertREC2100HLGtoExtendedSRGB(R,G,B):
+        systemGamma = 1.0
+        linearLightScaler = 1.0 / 0.265
+        (r1,g1,b1) = hlg_inverse_oetf(R,G,B)
+        (r2,g2,b2) = hlg_ootf(r1,g1,b1)
+        r3 = linearLightScaler * r2
+        g3 = linearLightScaler * g2
+        b3 = linearLightScaler * b2
+        (r4,g4,b4) = matrixXYZtoSRGB(matrixBT2020toXYZ(r3,g3,b3))
+        (r5,g5,b5) = srgb_inverse_eotf(r4,g4,b4)
+        return (r5,g5,b5)
+  ```
+
+##### Conversion from HLG to extended-linear-sRGB
+
+  _Input:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
+  _Output:_ Full-range non-linear floating-point `extended-linear-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+  _Process:_
+    1. Apply HLG EOTF to convert the non-linear `rec2100-hlg` Signal to linear Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
+      * apply inverse HLG OETF
+      * apply HLG OOTF to derive linear display light
+    2. Scale pixel values
+    3. Convert from ITU BT.2100-1 color space to SRGB color space
+
+    ```python
+        def convertREC2100HLGtoExtendedSRGB(R,G,B):
+          systemGamma = 1.0
+          linearLightScaler = 1.0 / 0.265
+          (r1,g1,b1) = hlg_inverse_oetf(R,G,B)
+          (r2,g2,b2) = hlg_ootf(r1,g1,b1)
+          r3 = linearLightScaler * r2
+          g3 = linearLightScaler * g2
+          b3 = linearLightScaler * b2
+          (r4,g4,b4) = matrixXYZtoSRGB(matrixBT2020toXYZ(r3,g3,b3))
+          return (r4,g4,b4)
+    ```
+
+
+##### Conversion from PQ to extended-sRGB
+
+  _Input:_ Full-range non-linear floating-point `rec2100-pq` pixel with black at 0.0 and diffuse white at ???. Values may exist outside the range 0.0 to 1.0.
+  _Output:_ Full-range non-linear floating-point `extended-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+  _Process:_
+
+##### Conversion from PQ to extended-linear-sRGB
+
+  _Input:_ Full-range non-linear floating-point `rec2100-pq` pixel with black at 0.0 and diffuse white at ???. Values may exist outside the range 0.0 to 1.0.
+  _Output:_ Full-range non-linear floating-point `extended-linear-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+  _Process:_
+
 
 ### Compositing the HDR `HTMLCanvasElement`
 

--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -118,7 +118,9 @@ Not these are only used to tonemap HDR images at the point of rendering for disp
 ##### HLG signal
 
 _Input:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
+
 _Output:_ Full-range non-linear floating-point `srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+
 _Process:_
   1. Linearize the HLG signal exploiting its backwards compatibility with SDR consumer displays
   2. Convert from ITU BT.2100 color space to SRGB color space
@@ -269,7 +271,9 @@ _Note:_ The domain of `EOTF<sup>-1</sup>` is [0, 10000]
 ##### Conversion from extended-sRGB to HLG
 
 _Input:_ Full-range non-linear floating-point `extended-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+
 _Output:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
+
 _Process:_
   1. Linearize using the SRGB EOTF
   2. Convert from `extended-srgb` color space to `rec2100-hlg` color space
@@ -301,7 +305,9 @@ _Note 2:_ See section 5.3 in ITU-R BT.2408-4 relating to negative transfer funct
 ##### Conversion from extended-linear-sRGB to HLG
 
 _Input:_ Full-range non-linear floating-point `extended-linear-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+
 _Output:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
+
 _Process:_
   1. Convert from `extended-linear-srgb` color space to `rec2100-hlg` color space
   2. Scale pixel values - See Note 1
@@ -325,19 +331,25 @@ _Process:_
 ##### Conversion from extended-sRGB to PQ
 
 _Input:_ Full-range non-linear floating-point `extended-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+
 _Output:_ Full-range non-linear floating-point `rec2100-pq` pixel with black at 0.0 and diffuse white at ???. Values may exist outside the range 0.0 to 1.0.
+
 _Process:_
 
 ##### Conversion from extended-sRGB to PQ
 
 _Input:_ Full-range non-linear floating-point `extended-linear-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+
 _Output:_ Full-range non-linear floating-point `rec2100-pq` pixel with black at 0.0 and diffuse white at ???. Values may exist outside the range 0.0 to 1.0.
+
 _Process:_
 
 ##### Conversion from HLG to extended-sRGB
 
 _Input:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
+
 _Output:_ Full-range non-linear floating-point `extended-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+
 _Process:_
   1. Apply HLG EOTF to convert the non-linear `rec2100-hlg` Signal to linear Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
     * apply inverse HLG OETF
@@ -363,7 +375,9 @@ _Process:_
 ##### Conversion from HLG to extended-linear-sRGB
 
   _Input:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
+
   _Output:_ Full-range non-linear floating-point `extended-linear-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+
   _Process:_
     1. Apply HLG EOTF to convert the non-linear `rec2100-hlg` Signal to linear Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
       * apply inverse HLG OETF
@@ -371,30 +385,34 @@ _Process:_
     2. Scale pixel values
     3. Convert from ITU BT.2100-1 color space to SRGB color space
 
-    ```python
-        def convertREC2100HLGtoExtendedSRGB(R,G,B):
-          systemGamma = 1.0
-          linearLightScaler = 1.0 / 0.265
-          (r1,g1,b1) = hlg_inverse_oetf(R,G,B)
-          (r2,g2,b2) = hlg_ootf(r1,g1,b1,systemGamma)
-          r3 = linearLightScaler * r2
-          g3 = linearLightScaler * g2
-          b3 = linearLightScaler * b2
-          (r4,g4,b4) = matrixXYZtoSRGB(matrixBT2020toXYZ(r3,g3,b3))
-          return (r4,g4,b4)
-    ```
+  ```python
+      def convertREC2100HLGtoExtendedSRGB(R,G,B):
+        systemGamma = 1.0
+        linearLightScaler = 1.0 / 0.265
+        (r1,g1,b1) = hlg_inverse_oetf(R,G,B)
+        (r2,g2,b2) = hlg_ootf(r1,g1,b1,systemGamma)
+        r3 = linearLightScaler * r2
+        g3 = linearLightScaler * g2
+        b3 = linearLightScaler * b2
+        (r4,g4,b4) = matrixXYZtoSRGB(matrixBT2020toXYZ(r3,g3,b3))
+        return (r4,g4,b4)
+  ```
 
 
 ##### Conversion from PQ to extended-sRGB
 
   _Input:_ Full-range non-linear floating-point `rec2100-pq` pixel with black at 0.0 and diffuse white at ???. Values may exist outside the range 0.0 to 1.0.
+
   _Output:_ Full-range non-linear floating-point `extended-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+
   _Process:_
 
 ##### Conversion from PQ to extended-linear-sRGB
 
   _Input:_ Full-range non-linear floating-point `rec2100-pq` pixel with black at 0.0 and diffuse white at ???. Values may exist outside the range 0.0 to 1.0.
+
   _Output:_ Full-range non-linear floating-point `extended-linear-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+
   _Process:_
 
 

--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -275,12 +275,12 @@ _Input:_ Full-range non-linear floating-point `extended-srgb` pixel with black a
 _Output:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
 
 _Process:_
-  1. Linearize using the SRGB EOTF
-  2. Convert from `extended-srgb` color space to `rec2100-hlg` color space
-  3. Scale pixel values - See Note 1
-  4. Apply HLG Inverse EOTF to convert to HLG from Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
-    * apply HLG Inverse OOTF
-    * apply HLG OETF - See Note 2
+ 1. Linearize using the SRGB EOTF
+ 2. Convert from `extended-srgb` color space to `rec2100-hlg` color space
+ 3. Scale pixel values - See Note 1
+ 4. Apply HLG Inverse EOTF to convert to HLG from Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
+  * apply HLG Inverse OOTF
+  * apply HLG OETF - See Note 2
 
 _Note 1:_ As `rec2100-hlg` is a relative format, the brightness of the virtual monitor used for mathematical transforms can be chosen to be any level. In this transform it is chosen to be 302 cd/m2 so that the brightness of diffuse white matches the diffuse white of sRGB (80 cd/m2). Using the extended range gamma formula in footnote 2 of BT.2100, this also sets the HLG Inverse OOTF to be unity. The value 0.265 is calculated by taking the inverse OETF of 0.75, the `rec2100-hlg` diffuse white level.
 
@@ -309,11 +309,11 @@ _Input:_ Full-range non-linear floating-point `extended-linear-srgb` pixel with 
 _Output:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
 
 _Process:_
-  1. Convert from `extended-linear-srgb` color space to `rec2100-hlg` color space
-  2. Scale pixel values - See Note 1
-  3. Apply HLG Inverse EOTF to convert to HLG from Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
-    * apply HLG Inverse OOTF
-    * apply HLG OETF - See Note 2
+1. Convert from `extended-linear-srgb` color space to `rec2100-hlg` color space
+2. Scale pixel values - See Note 1
+3. Apply HLG Inverse EOTF to convert to HLG from Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
+ * apply HLG Inverse OOTF
+ * apply HLG OETF - See Note 2
 
 ```python
     def convertExtendedLinearSRGBtoREC2100HLG(R,G,B):
@@ -351,12 +351,12 @@ _Input:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 
 _Output:_ Full-range non-linear floating-point `extended-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
 
 _Process:_
-  1. Apply HLG EOTF to convert the non-linear `rec2100-hlg` Signal to linear Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
-    * apply inverse HLG OETF
-    * apply HLG OOTF to derive linear display light
-  2. Scale pixel values
-  3. Convert from ITU BT.2100-1 color space to SRGB color space
-  4. Convert to non-linear SRGB using the SRGB Inverse EOTF
+1. Apply HLG EOTF to convert the non-linear `rec2100-hlg` Signal to linear Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
+ * apply inverse HLG OETF
+ * apply HLG OOTF to derive linear display light
+2. Scale pixel values
+3. Convert from ITU BT.2100-1 color space to SRGB color space
+4. Convert to non-linear SRGB using the SRGB Inverse EOTF
 
   ```python
       def convertREC2100HLGtoExtendedSRGB(R,G,B):
@@ -379,11 +379,11 @@ _Process:_
   _Output:_ Full-range non-linear floating-point `extended-linear-srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
 
   _Process:_
-    1. Apply HLG EOTF to convert the non-linear `rec2100-hlg` Signal to linear Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
-      * apply inverse HLG OETF
-      * apply HLG OOTF to derive linear display light
-    2. Scale pixel values
-    3. Convert from ITU BT.2100-1 color space to SRGB color space
+  1. Apply HLG EOTF to convert the non-linear `rec2100-hlg` Signal to linear Pseudo-Display Light with Lw = 302 cd/m2 - See Note 1
+   * apply inverse HLG OETF
+   * apply HLG OOTF to derive linear display light
+  2. Scale pixel values
+  3. Convert from ITU BT.2100-1 color space to SRGB color space
 
   ```python
       def convertREC2100HLGtoExtendedSRGB(R,G,B):

--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -110,6 +110,32 @@ display with different dynamic range, occurs in different parts of the system de
 
 ![Tone mapping scenarios](./tone-mapping-scenarios.png)
 
+#### Suggested Tone mapping for HDR content on sRGB displays
+Not these are only used to tonemap HDR images at the point of rendering for display when the display is known to be an sRGB display.  They are not used for conversion between colour spaces which is defined in section XXXX.
+
+##### PQ signal
+
+##### HLG signal
+
+_Input:_ Full-range non-linear floating-point `rec2100-hlg` pixel with black at 0.0 and diffuse white at 0.75. Values may exist outside the range 0.0 to 1.0.
+_Output:_ Full-range non-linear floating-point `srgb` pixel with black at 0.0 and diffuse white at 1.0. Values may exist outside the range 0.0 to 1.0.
+_Process:_
+  1. Linearize the HLG signal exploiting its backwards compatibility with SDR consumer displays
+  2. Convert from ITU BT.2100 color space to SRGB color space
+  3. Convert to SRGB using the SRGB Inverse EOTF
+
+_Note 3_ This transform utilises the backwards compatibility of ITU-R BT.2100 HLG HDR with consumer electronic displays.
+
+```python
+    def tonemapREC2100HLGtoSRGBdisplay(R,G,B):
+      systemGamma = 2.2
+      (r1,g1,b1) = hlg_ootf(R,G,B,systemGamma)
+      (r2,g2,b2) = matrixXYZtoSRGB(matrixBT2020toXYZ(r1,g1,b1))
+      (r3,g3,b3) = srgb_inverse_eotf(r2,g2,b2)
+      (r4,g4,b4) = clipper_0_1(r3,g3,b3)
+      return (r4,g4,b4)
+```
+
 ### Color spaces
 
 #### General
@@ -325,7 +351,7 @@ _Process:_
         systemGamma = 1.0
         linearLightScaler = 1.0 / 0.265
         (r1,g1,b1) = hlg_inverse_oetf(R,G,B)
-        (r2,g2,b2) = hlg_ootf(r1,g1,b1)
+        (r2,g2,b2) = hlg_ootf(r1,g1,b1,systemGamma)
         r3 = linearLightScaler * r2
         g3 = linearLightScaler * g2
         b3 = linearLightScaler * b2
@@ -350,7 +376,7 @@ _Process:_
           systemGamma = 1.0
           linearLightScaler = 1.0 / 0.265
           (r1,g1,b1) = hlg_inverse_oetf(R,G,B)
-          (r2,g2,b2) = hlg_ootf(r1,g1,b1)
+          (r2,g2,b2) = hlg_ootf(r1,g1,b1,systemGamma)
           r3 = linearLightScaler * r2
           g3 = linearLightScaler * g2
           b3 = linearLightScaler * b2

--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -128,14 +128,15 @@ _Process:_
 
 _Note 3_ This transform utilises the backwards compatibility of ITU-R BT.2100 HLG HDR with consumer electronic displays.
 
-```python
-    def tonemapREC2100HLGtoSRGBdisplay(R,G,B):
-      systemGamma = 2.2
-      (r1,g1,b1) = hlg_ootf(R,G,B,systemGamma)
-      (r2,g2,b2) = matrixXYZtoSRGB(matrixBT2020toXYZ(r1,g1,b1))
-      (r3,g3,b3) = srgb_inverse_eotf(r2,g2,b2)
-      (r4,g4,b4) = clipper_0_1(r3,g3,b3)
-      return (r4,g4,b4)
+```javascript
+function tonemapREC2100HLGtoSRGBdisplay(r, g, b) {
+  const systemGamma = 2.2;
+  const [r1, g1, b1] = hlg_ootf(r, g, b, systemGamma);
+  const [r2, g2, b2] = matrixXYZtoSRGB(matrixBT2020toXYZ(r1, g1, b1));
+  const [r3, g3, b3] = srgb_inverse_eotf(r2, g2, b2);
+  const [r4, g4, b4] = clipper_0_1(r3, g3, b3);
+  return [r4, g4, b4];
+}
 ```
 
 ### Color spaces
@@ -286,20 +287,26 @@ _Note 1:_ As `rec2100-hlg` is a relative format, the brightness of the virtual m
 
 _Note 2:_ See section 5.3 in ITU-R BT.2408-4 relating to negative transfer functions in format conversions.
 
-```python
-    def convertExtendedSRGBtoREC2100HLG(R,G,B):
-      systemGamma = 1.0
-      linearLightScaler = 0.265
-      r1 = srgb_eotf(R)
-      g1 = srgb_eotf(G)
-      b1 = srgb_eotf(B)
-      (r2,g2,b2) = matrixXYZtoBT2020(matrixSRGBtoXYZ(r1,g1,b1))
-      r3 = linearLightScaler * r2
-      g3 = linearLightScaler * g2
-      b3 = linearLightScaler * b2
-      (r4,g4,b4) = hlg_inverse_ootf(r3,g3,b3,systemGamma)
-      (r5,g5,b5) = hlg_oetf(r4,g4,b4)
-      return (r5,g5,b5)
+```javascript
+function convertExtendedSRGBtoREC2100HLG(r, g, b) {
+  const systemGamma = 1.0;
+  const linearLightScaler = 0.265;
+
+  const r1 = srgb_eotf(r);
+  const g1 = srgb_eotf(g);
+  const b1 = srgb_eotf(b);
+
+  const [r2, g2, b2] = matrixXYZtoBT2020(matrixSRGBtoXYZ(r1,g1,b1));
+
+  const r3 = linearLightScaler * r2;
+  const g3 = linearLightScaler * g2;
+  const b3 = linearLightScaler * b2;
+
+  const [r4, g4, b4] = hlg_inverse_ootf(r3, g3, b3, systemGamma);
+  const [r5, g5, b5] = hlg_oetf(r4, g4, b4);
+
+  return [r5, g5, b5]
+}
 ```
 
 ##### Conversion from extended-linear-sRGB to HLG
@@ -315,17 +322,22 @@ _Process:_
  * apply HLG Inverse OOTF
  * apply HLG OETF - See Note 2
 
-```python
-    def convertExtendedLinearSRGBtoREC2100HLG(R,G,B):
-      systemGamma = 1.0
-      linearLightScaler = 0.265
-      (r2,g2,b2) = matrixXYZtoBT2020(matrixSRGBtoXYZ(r1,g1,b1))
-      r3 = linearLightScaler * r2
-      g3 = linearLightScaler * g2
-      b3 = linearLightScaler * b2
-      (r4,g4,b4) = hlg_inverse_ootf(r3,g3,b3,systemGamma)
-      (r5,g5,b5) = hlg_oetf(r4,g4,b4)
-      return (r5,g5,b5)
+```javascript
+function convertExtendedLinearSRGBtoREC2100HLG(r, g, b) {
+  const systemGamma = 1.0;
+  const linearLightScaler = 0.265;
+
+  const [r2, g2, b2] = matrixXYZtoBT2020(matrixSRGBtoXYZ(r1, g1, b1));
+
+  const r3 = linearLightScaler * r2;
+  const g3 = linearLightScaler * g2;
+  const b3 = linearLightScaler * b2;
+  
+  const [r4, g4, b4] = hlg_inverse_ootf(r3, g3, b3, systemGamma);
+  const [r5, g5, b5] = hlg_oetf(r4, g4, b4);
+  
+  return [r5, g5, b5];
+}
 ```
 
 ##### Conversion from extended-sRGB to PQ
@@ -358,19 +370,25 @@ _Process:_
 3. Convert from ITU BT.2100-1 color space to SRGB color space
 4. Convert to non-linear SRGB using the SRGB Inverse EOTF
 
-  ```python
-      def convertREC2100HLGtoExtendedSRGB(R,G,B):
-        systemGamma = 1.0
-        linearLightScaler = 1.0 / 0.265
-        (r1,g1,b1) = hlg_inverse_oetf(R,G,B)
-        (r2,g2,b2) = hlg_ootf(r1,g1,b1,systemGamma)
-        r3 = linearLightScaler * r2
-        g3 = linearLightScaler * g2
-        b3 = linearLightScaler * b2
-        (r4,g4,b4) = matrixXYZtoSRGB(matrixBT2020toXYZ(r3,g3,b3))
-        (r5,g5,b5) = srgb_inverse_eotf(r4,g4,b4)
-        return (r5,g5,b5)
-  ```
+
+```javascript
+function convertREC2100HLGtoExtendedSRGB(r, g, b) {
+  const systemGamma = 1.0;
+  const linearLightScaler = 1.0 / 0.265;
+
+  const [r1, g1, b1] = hlg_inverse_oetf(r, g, b);
+  const [r2, g2, b2] = hlg_ootf(r1, g1, b1, systemGamma);
+
+  const r3 = linearLightScaler * r2;
+  const g3 = linearLightScaler * g2;
+  const b3 = linearLightScaler * b2;
+
+  const [r4, g4, b4] = matrixXYZtoSRGB(matrixBT2020toXYZ(r3, g3, b3));
+  const [r5, g5, b5] = srgb_inverse_eotf(r4, g4, b4);
+
+  return [r5, g5, b5];
+}
+```
 
 ##### Conversion from HLG to extended-linear-sRGB
 
@@ -385,18 +403,23 @@ _Process:_
   2. Scale pixel values
   3. Convert from ITU BT.2100-1 color space to SRGB color space
 
-  ```python
-      def convertREC2100HLGtoExtendedSRGB(R,G,B):
-        systemGamma = 1.0
-        linearLightScaler = 1.0 / 0.265
-        (r1,g1,b1) = hlg_inverse_oetf(R,G,B)
-        (r2,g2,b2) = hlg_ootf(r1,g1,b1,systemGamma)
-        r3 = linearLightScaler * r2
-        g3 = linearLightScaler * g2
-        b3 = linearLightScaler * b2
-        (r4,g4,b4) = matrixXYZtoSRGB(matrixBT2020toXYZ(r3,g3,b3))
-        return (r4,g4,b4)
-  ```
+```javascript
+function convertREC2100HLGtoExtendedLinearSRGB(r, g, b) {
+  const systemGamma = 1.0;
+  const linearLightScaler = 1.0 / 0.265;
+
+  const [r1, g1, b1] = hlg_inverse_oetf(r, g, b);
+  const [r2, g2, b2] = hlg_ootf(r1, g1, b1, systemGamma);
+
+  const r3 = linearLightScaler * r2;
+  const g3 = linearLightScaler * g2;
+  const b3 = linearLightScaler * b2;
+
+  const [r4, g4, b4] = matrixXYZtoSRGB(matrixBT2020toXYZ(r3, g3, b3));
+
+  return [r4, g4, b4];
+}
+```
 
 
 ##### Conversion from PQ to extended-sRGB

--- a/hdr_html_canvas_element.md
+++ b/hdr_html_canvas_element.md
@@ -160,7 +160,7 @@ The component signals are mapped to red, green and blue tristimulus values accor
 
 #### rec2100-pq
 
-The component signals are mapped to red, green and blue tristimulus values according to the PQ system system specified in Rec. ITU-R BT.2100.
+The component signals are mapped to red, green and blue tristimulus values according to the Perceptual Quantizer (PQ) system system specified in Rec. ITU-R BT.2100.
 
 ### Conversion between color spaces
 
@@ -188,6 +188,7 @@ _Note:_ The system colorimetry specified in Rec. ITU-R BT.2100 is identical to t
 The conversion from color space A to color space B is performed according to the following steps:
 
 * apply the inverse transfer function of color space A
+* apply any linear light scaling to correctly map the level of perceived diffuse white level in to color space B
 * convert to the connection space by multiplying by the connection matrix of color space A
 * convert to color space B by multiplying by by the inverse of the connection matrix of color space B
 * apply the transfer function of color space B
@@ -212,11 +213,11 @@ Also see note in the Issues section at the bottom about whether this space shoul
 
 #### `rec2100-hlg`
 
-* Transfer function: HLG Reference OETF specified at Rec. ITU-R BT.2100
-
-_Note:_ The range of the function is [0, 1].
+* Transfer function: HLG Reference EOTF specified at Rec. ITU-R BT.2100 with a System Gamma of Unity
 
 * Connection matrix: Identity
+
+* Linear light scaling: 1.0/0.265
 
 _Note:_ Converting from `rec2100-hlg` to any SDR color space will not result in clipping.
 
@@ -224,11 +225,17 @@ _Note:_ Converting from `rec2100-hlg` to any SDR color space will not result in 
 
 * Transfer function: `EOTF<sup>-1</sup>[F<sub>D</sub>/300]` where `EOTF<sup>-1</sup>` is the inverse of the Reference PQ EOTF specified at Rec. ITU-R BT.2100.
 
+* Connection matrix: Identity
+
+* Linear light scaling: 1.0/0.265
+
 _Note:_ The factor of 300 is such that a display luminance of 300 cd/m<sup>2</sup> results in a linear color value of 1 in the connection color space.
 
 _Note:_ The domain of `EOTF<sup>-1</sup>` is [0, 10000]
 
-* Connection matrix: Identity
+
+
+
 
 ### Compositing the HDR `HTMLCanvasElement`
 


### PR DESCRIPTION
Added Javascript examples for Conversion between extended-sRGB/extended-linear-sRGB and HLG, and a suggested Tone-mapping to be used when showing HLG on an sRGB display.

Two Questions:

- Should we add Javascript examples of the various transfer functions mentioned?
- Should we link to the ITU guide for creating colour space to CIE XYZ matrices?

I've spoken to Timo about creating similar examples for PQ.