### PR TITLE
Correct priority order of PNG chunks.

### DIFF
--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -26,10 +26,9 @@ A PNG may contain multiple chunks with color space information. A PNG viewer sho
 
 * `cICP`
 * `iCCN`
-* `iCCP`
-* `gAMA`
-* `cHRM`
 * `sRGB`
+* `iCCP`
+* `gAMA` & `cHRM`
 
 ### cICP chunk
 


### PR DESCRIPTION
The existing HDR in PNG requirements doc lists the 'sRGB' chunk as
lowest priority.

However, the PNG spec [1] says that the 'sRGB' chunk has a higher priority
than 'gAMA' and 'cHRM', as it is short-hand for an exact set of 'gAMA'
and 'cHRM' values.

This commit corrects the priority order of the PNG chunks.

[1] https://www.w3.org/TR/2003/REC-PNG-20031110/#11sRGB