### PR TITLE
Clarify cICP fallthrough

### DIFF
--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -30,7 +30,7 @@ A PNG may contain multiple chunks with color space information. A PNG viewer sho
 * `iCCP`
 * `gAMA` & `cHRM`
 
-Note: If the PNG decoder knows the display / surface cannot use the cICP code point, it should ignore the cICP chunk and continue down the priority list.
+If the PNG decoder knows the display / surface cannot use the cICP code point, it should ignore the cICP chunk and continue down the priority list.
 
 ### cICP chunk
 

--- a/hdr-in-png-requirements.md
+++ b/hdr-in-png-requirements.md
@@ -30,6 +30,8 @@ A PNG may contain multiple chunks with color space information. A PNG viewer sho
 * `iCCP`
 * `gAMA` & `cHRM`
 
+Note: If the PNG decoder knows the display / surface cannot use the cICP code point, it should ignore the cICP chunk and continue down the priority list.
+
 ### cICP chunk
 
 This chunk SHALL come before the `IDAT` chunk.


### PR DESCRIPTION
If the cICP specifies a code point which the decoder knows cannot be
used by the display / surface, the cICP chunk should be ignored. This
commit adds that wording.